### PR TITLE
Auto-fix note categories

### DIFF
--- a/release-notes/check/index.js
+++ b/release-notes/check/index.js
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import matter from "gray-matter";
 
-import { categoryOrder } from "../util.js";
+import { categoryAutocorrections, categoryOrder } from "../util.js";
 
 console.log("Looking in " + fs.realpathSync("upcoming-release-notes"));
 
@@ -31,6 +31,9 @@ function reportError(message) {
   if (!data.category) {
     reportError(`Release note is missing a category.`);
     return;
+  }
+  if (categoryAutocorrections[data.category]) {
+    data.category = categoryAutocorrections[data.category];
   }
   if (!categoryOrder.includes(data.category)) {
     reportError(

--- a/release-notes/generate/index.js
+++ b/release-notes/generate/index.js
@@ -5,7 +5,7 @@ import * as childProcess from "node:child_process";
 import matter from "gray-matter";
 import listify from "listify";
 
-import { categoryOrder } from "../util.js";
+import { categoryAutocorrections, categoryOrder } from "../util.js";
 
 const exec = promisify(childProcess.exec);
 
@@ -132,7 +132,7 @@ async function parseReleaseNotes(dir) {
         { finalWord: "&" }
       );
       return {
-        category: data.category,
+        category: categoryAutocorrections[data.category] ?? data.category,
         value: `- [#${number}](https://github.com/actualbudget/${repo}/pull/${number}) ${body.trim()} \u{2014} thanks ${authors}`,
       };
     });

--- a/release-notes/util.js
+++ b/release-notes/util.js
@@ -1,6 +1,12 @@
+export const categoryAutocorrections = {
+  "Feature": "Features",
+  "Enhancement": "Enhancements",
+  "Bugfix": "Bugfixes",
+};
+
 export const categoryOrder = [
   "Features",
   "Enhancements",
-  "Bugfix",
+  "Bugfixes",
   "Maintenance",
 ];


### PR DESCRIPTION
Tested this by running the scripts locally, and their output seemed to be reasonable.

One thing to call out, I changed "Bugfix" to "Bugfixes" to be consistent about the plurals. Don't feel that strongly though, so let me know if you'd like it the other way round! If we all agree on this change, I'll update the workflows in-repo to match (we won't need to update existing notes since the auto-fix will handle it).